### PR TITLE
Update pyproject.toml

### DIFF
--- a/evaluation/fishfarm/pyproject.toml
+++ b/evaluation/fishfarm/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "fishfarm"
 description = ""


### PR DESCRIPTION
edited  for duplicate [project] repeats in ~/evaluation/fishfarm/pyproject.toml causing fishfarm build to fail:

'''
tomllib.TOMLDecodeError: Cannot declare ('project',) twice (at line 110, column 9)
'''
after edit:

Successfully built fishfarm
Installing collected packages: colorlog, fishfarm
Successfully installed colorlog-6.9.0 fishfarm-0.1.0.dev0